### PR TITLE
feat: add time-series data logging with graph and CSV export

### DIFF
--- a/lib/open_plaato_keg.ex
+++ b/lib/open_plaato_keg.ex
@@ -42,6 +42,11 @@ defmodule OpenPlaatoKeg do
     beverages_path = Path.join(db_folder, "beverages.bin")
     {:ok, _} = :dets.open_file(:beverages, [{:file, String.to_charlist(beverages_path)}])
 
+    # Time-series data log for kegs and airlocks
+    data_log_path = Path.join(db_folder, "data_log.bin")
+    {:ok, _} = :dets.open_file(:data_log, [{:file, String.to_charlist(data_log_path)}])
+    OpenPlaatoKeg.Models.DataLog.init_throttle()
+
     # Ensure tap handle image directory exists (persistent volume)
     File.mkdir_p!(Path.join(db_folder, "tap-handles"))
 

--- a/lib/open_plaato_keg/http_router.ex
+++ b/lib/open_plaato_keg/http_router.ex
@@ -6,6 +6,7 @@ defmodule OpenPlaatoKeg.HttpRouter do
   alias OpenPlaatoKeg.Models.AirlockData
   alias OpenPlaatoKeg.Models.BeerDB
   alias OpenPlaatoKeg.Models.BeverageDB
+  alias OpenPlaatoKeg.Models.DataLog
   alias OpenPlaatoKeg.Models.KegData
   alias OpenPlaatoKeg.Models.TransferScaleData
   alias OpenPlaatoKeg.MqttHandler
@@ -397,6 +398,13 @@ defmodule OpenPlaatoKeg.HttpRouter do
         # Send to Grainfather/Brewfather if enabled (throttled to every 15 min by each module)
         OpenPlaatoKeg.Grainfather.maybe_send(airlock_id, temperature, bubbles_per_min)
         OpenPlaatoKeg.Brewfather.maybe_send(airlock_id, temperature, bubbles_per_min)
+
+        log_data =
+          %{"temperature" => temperature, "bubbles_per_min" => bubbles_per_min}
+          |> Enum.reject(fn {_, v} -> v == nil end)
+          |> Map.new()
+
+        DataLog.log(:airlock, airlock_id, log_data)
 
         response =
           %{status: "ok", command: "airlock_data"}
@@ -1092,11 +1100,73 @@ defmodule OpenPlaatoKeg.HttpRouter do
     json_response(conn, 200, %{status: "ok", deleted: scale_id})
   end
 
+  # ============================================
+  # Data Log – time-series history for kegs and airlocks
+  # ============================================
+
+  get "api/kegs/:id/log/csv" do
+    id = conn.params["id"]
+    range = conn.query_params["range"] || "30d"
+    {from_ts, to_ts} = parse_time_range(range)
+    entries = DataLog.get(:keg, id, from_ts, to_ts)
+    csv = DataLog.to_csv(:keg, entries)
+
+    conn
+    |> put_resp_content_type("text/csv")
+    |> put_resp_header("content-disposition", "attachment; filename=\"keg-#{id}-log.csv\"")
+    |> send_resp(200, csv)
+  end
+
+  get "api/kegs/:id/log" do
+    id = conn.params["id"]
+    range = conn.query_params["range"] || "24h"
+    {from_ts, to_ts} = parse_time_range(range)
+    entries = DataLog.get(:keg, id, from_ts, to_ts)
+    json_response(conn, 200, entries)
+  end
+
+  get "api/airlocks/:id/log/csv" do
+    id = conn.params["id"]
+    range = conn.query_params["range"] || "30d"
+    {from_ts, to_ts} = parse_time_range(range)
+    entries = DataLog.get(:airlock, id, from_ts, to_ts)
+    csv = DataLog.to_csv(:airlock, entries)
+
+    conn
+    |> put_resp_content_type("text/csv")
+    |> put_resp_header("content-disposition", "attachment; filename=\"airlock-#{id}-log.csv\"")
+    |> send_resp(200, csv)
+  end
+
+  get "api/airlocks/:id/log" do
+    id = conn.params["id"]
+    range = conn.query_params["range"] || "24h"
+    {from_ts, to_ts} = parse_time_range(range)
+    entries = DataLog.get(:airlock, id, from_ts, to_ts)
+    json_response(conn, 200, entries)
+  end
+
   match _ do
     send_resp(conn, 404, "Not found")
   end
 
   # Helper functions
+
+  defp parse_time_range(range) do
+    now = System.system_time(:second)
+
+    seconds =
+      case range do
+        "1h" -> 3_600
+        "6h" -> 21_600
+        "24h" -> 86_400
+        "7d" -> 604_800
+        "30d" -> 2_592_000
+        _ -> 86_400
+      end
+
+    {now - seconds, now}
+  end
 
   defp json_response(conn, status, data) do
     conn

--- a/lib/open_plaato_keg/keg_data_processor.ex
+++ b/lib/open_plaato_keg/keg_data_processor.ex
@@ -4,6 +4,7 @@ defmodule OpenPlaatoKeg.KegDataProcessor do
 
   alias OpenPlaatoKeg.BlynkProtocol
   alias OpenPlaatoKeg.Models.AirlockData
+  alias OpenPlaatoKeg.Models.DataLog
   alias OpenPlaatoKeg.Models.KegData
   alias OpenPlaatoKeg.PlaatoData
   alias OpenPlaatoKeg.PlaatoProtocol
@@ -147,6 +148,20 @@ defmodule OpenPlaatoKeg.KegDataProcessor do
        fn -> confirmed_keg? and amount_left_changed? and OpenPlaatoKeg.barhelper_config()[:enabled] end}
     ])
 
+    if confirmed_keg? and id != nil do
+      log_data =
+        %{
+          "amount_left" => Keyword.get(data, :amount_left),
+          "keg_temperature" => Keyword.get(data, :keg_temperature),
+          "percent_of_beer_left" => Keyword.get(data, :percent_of_beer_left),
+          "is_pouring" => Keyword.get(data, :is_pouring)
+        }
+        |> Enum.reject(fn {_, v} -> v == nil end)
+        |> Map.new()
+
+      DataLog.log(:keg, id, log_data)
+    end
+
     {:noreply, state}
   end
 
@@ -196,6 +211,16 @@ defmodule OpenPlaatoKeg.KegDataProcessor do
       OpenPlaatoKeg.WebSocketHandler.publish_airlock(id, airlock_fields)
       OpenPlaatoKeg.Grainfather.maybe_send(id, Keyword.get(data, :airlock_temperature), bpm && to_string(bpm))
       OpenPlaatoKeg.Brewfather.maybe_send(id, Keyword.get(data, :airlock_temperature), bpm && to_string(bpm), bubble_total)
+
+      log_data =
+        %{
+          "temperature" => Keyword.get(airlock_fields, :temperature),
+          "bubbles_per_min" => bpm && to_string(bpm)
+        }
+        |> Enum.reject(fn {_, v} -> v == nil end)
+        |> Map.new()
+
+      DataLog.log(:airlock, id, log_data)
     end
 
     {:noreply, new_state}

--- a/lib/open_plaato_keg/models/data_log.ex
+++ b/lib/open_plaato_keg/models/data_log.ex
@@ -1,0 +1,123 @@
+defmodule OpenPlaatoKeg.Models.DataLog do
+  @moduledoc """
+  Time-series log of keg and airlock sensor readings, backed by a DETS table.
+
+  Entries are keyed by {device_type, device_id, unix_timestamp_seconds} so they
+  can be range-queried by device. A per-device ETS throttle prevents logging
+  more than once per minute for kegs (which send continuous data); airlocks
+  naturally transmit every ~290 seconds so no throttle is applied.
+  """
+
+  @table :data_log
+  @throttle_table :data_log_throttle
+  @min_keg_interval_seconds 60
+
+  # Called once at app startup to create the in-memory throttle table.
+  def init_throttle do
+    :ets.new(@throttle_table, [:named_table, :set, :public])
+  end
+
+  @doc """
+  Log a data point for `device_type` (`:keg` or `:airlock`) and `device_id`.
+  `data` must be a string-keyed map. Returns `:ok` (skipped if throttled).
+  """
+  def log(device_type, device_id, data) when is_map(data) and map_size(data) > 0 do
+    now = System.system_time(:second)
+
+    if should_log?(device_type, device_id, now) do
+      :ets.insert(@throttle_table, {{device_type, device_id}, now})
+      :dets.insert(@table, {{device_type, device_id, now}, data})
+    end
+
+    :ok
+  end
+
+  def log(_device_type, _device_id, _data), do: :ok
+
+  @doc """
+  Return all log entries for `device_type`/`device_id` between two Unix
+  timestamps (inclusive). Entries are sorted ascending by timestamp and each
+  entry has a `"timestamp"` key added.
+  """
+  def get(device_type, device_id, from_ts, to_ts) do
+    matchspec = [
+      {
+        {{device_type, device_id, :"$1"}, :"$2"},
+        [{:>=, :"$1", from_ts}, {:"=<", :"$1", to_ts}],
+        [{{:"$1", :"$2"}}]
+      }
+    ]
+
+    case :dets.select(@table, matchspec) do
+      {:error, _} ->
+        []
+
+      results ->
+        results
+        |> Enum.sort_by(fn {ts, _} -> ts end)
+        |> Enum.map(fn {ts, data} -> Map.put(data, "timestamp", ts) end)
+    end
+  end
+
+  @doc """
+  Serialise `entries` (as returned by `get/4`) to a CSV string.
+  """
+  def to_csv(:keg, entries) do
+    headers = ["timestamp", "amount_left", "keg_temperature", "percent_of_beer_left", "is_pouring"]
+    rows_to_csv(headers, entries)
+  end
+
+  def to_csv(:airlock, entries) do
+    headers = ["timestamp", "temperature", "bubbles_per_min"]
+    rows_to_csv(headers, entries)
+  end
+
+  @doc """
+  Delete all log entries older than `days_to_keep` days (default 90).
+  """
+  def prune(days_to_keep \\ 90) do
+    cutoff = System.system_time(:second) - days_to_keep * 86_400
+
+    matchspec = [
+      {
+        {{:"$1", :"$2", :"$3"}, :"_"},
+        [{:<, :"$3", cutoff}],
+        [{{:"$1", :"$2", :"$3"}}]
+      }
+    ]
+
+    case :dets.select(@table, matchspec) do
+      {:error, _} ->
+        :ok
+
+      keys ->
+        Enum.each(keys, fn {type, id, ts} ->
+          :dets.delete(@table, {type, id, ts})
+        end)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp should_log?(:keg, device_id, now) do
+    case :ets.lookup(@throttle_table, {:keg, device_id}) do
+      [{{:keg, ^device_id}, last_ts}] -> now - last_ts >= @min_keg_interval_seconds
+      [] -> true
+    end
+  end
+
+  defp should_log?(_device_type, _device_id, _now), do: true
+
+  defp rows_to_csv(headers, entries) do
+    rows =
+      Enum.map(entries, fn entry ->
+        Enum.map(headers, &(Map.get(entry, &1) || ""))
+      end)
+
+    [headers | rows]
+    |> Enum.map(&Enum.join(&1, ","))
+    |> Enum.join("\n")
+  end
+end

--- a/priv/static/airlock-setup.html
+++ b/priv/static/airlock-setup.html
@@ -18,6 +18,7 @@
         <div class="navbar-start">
           <a class="navbar-item" href="/index.html">Home</a>
           <a class="navbar-item" href="/taplist.html">Tap List</a>
+          <a class="navbar-item" href="/history.html">History</a>
           <div class="navbar-item has-dropdown" id="configureDropdown">
             <a class="navbar-link" onclick="toggleDropdown(event)">Configure</a>
             <div class="navbar-dropdown">

--- a/priv/static/beverages.html
+++ b/priv/static/beverages.html
@@ -39,6 +39,7 @@
         <div class="navbar-start">
           <a class="navbar-item" href="/index.html">Home</a>
           <a class="navbar-item" href="/taplist.html">Tap List</a>
+          <a class="navbar-item" href="/history.html">History</a>
           <div class="navbar-item has-dropdown" id="configureDropdown">
             <a class="navbar-link" onclick="toggleDropdown(event)">Configure</a>
             <div class="navbar-dropdown">

--- a/priv/static/history.html
+++ b/priv/static/history.html
@@ -1,0 +1,447 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>History</title>
+    <style>
+      @import url("style.css");
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
+</head>
+<body>
+  <div id="header_container">
+    <div id="page_container" class="container pageEntry"></div>
+    <nav class="navbar" role="navigation" aria-label="main navigation">
+      <div class="navbar-brand">
+        <a
+          role="button"
+          class="navbar-burger burger"
+          aria-label="menu"
+          aria-expanded="false"
+          data-target="navbarMenu"
+        >
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+        </a>
+      </div>
+
+      <div id="navbarMenu" class="navbar-menu">
+        <div class="navbar-start">
+          <a class="navbar-item" href="/index.html">Home</a>
+          <a class="navbar-item" href="/taplist.html">Tap List</a>
+          <a class="navbar-item is-active" href="/history.html">History</a>
+          <div class="navbar-item has-dropdown" id="configureDropdown">
+            <a class="navbar-link" onclick="toggleDropdown(event)">Configure</a>
+            <div class="navbar-dropdown">
+              <a class="navbar-item" href="/taplist-setup.html">Tap Setup</a>
+              <a class="navbar-item" href="/tap-handles.html">Tap Handles</a>
+              <a class="navbar-item" href="/setup.html">Keg Setup</a>
+              <a class="navbar-item" href="/airlock-setup.html">Airlock Setup</a>
+              <a class="navbar-item" href="/transfer-scales.html">Transfer Scales</a>
+              <a class="navbar-item" href="/beverages.html">Beverages</a>
+            </div>
+          </div>
+        </div>
+        <div class="navbar-end">
+          <span class="navbar-item" id="serverVersion" style="font-size:0.75rem;opacity:0.5;"></span>
+        </div>
+      </div>
+    </nav>
+  </div>
+
+  <section class="section">
+    <div class="container">
+      <h1 class="title is-1">History</h1>
+
+      <!-- Device type tabs -->
+      <div class="tabs is-boxed" id="deviceTypeTabs">
+        <ul>
+          <li class="is-active" data-type="keg"><a>Kegs</a></li>
+          <li data-type="airlock"><a>Airlocks</a></li>
+        </ul>
+      </div>
+
+      <!-- Controls row -->
+      <div class="columns is-vcentered mb-4">
+        <div class="column is-narrow">
+          <div class="field">
+            <label class="label">Device</label>
+            <div class="control">
+              <div class="select">
+                <select id="deviceSelect">
+                  <option value="">Loading...</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="column is-narrow">
+          <div class="field">
+            <label class="label">Time Range</label>
+            <div class="control">
+              <div class="buttons has-addons" id="rangeButtons">
+                <button class="button" data-range="1h">1h</button>
+                <button class="button" data-range="6h">6h</button>
+                <button class="button is-info" data-range="24h">24h</button>
+                <button class="button" data-range="7d">7d</button>
+                <button class="button" data-range="30d">30d</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="column is-narrow" style="padding-top: 1.75rem;">
+          <button class="button is-light" id="downloadBtn" title="Download CSV">
+            &#8595; Download CSV
+          </button>
+        </div>
+        <div class="column is-narrow" style="padding-top: 1.75rem;">
+          <span id="entryCount" style="font-size:0.875rem; opacity:0.6;"></span>
+        </div>
+      </div>
+
+      <!-- Chart -->
+      <div class="box" style="position: relative; min-height: 350px;">
+        <div id="noDataMsg" style="display:none; text-align:center; padding: 4rem 0; color: #aaa;">
+          No data for this device and time range.
+        </div>
+        <canvas id="historyChart"></canvas>
+      </div>
+
+    </div>
+  </section>
+
+  <script>
+    // ----------------------------------------------------------------
+    // State
+    // ----------------------------------------------------------------
+    let deviceType = 'keg';
+    let selectedDevice = null;
+    let selectedRange = '24h';
+    let chart = null;
+
+    // ----------------------------------------------------------------
+    // Navbar helpers
+    // ----------------------------------------------------------------
+    function toggleDropdown(e) {
+      e.preventDefault();
+      document.getElementById('configureDropdown').classList.toggle('is-open');
+    }
+    document.addEventListener('click', e => {
+      if (!e.target.closest('#configureDropdown'))
+        document.getElementById('configureDropdown')?.classList.remove('is-open');
+    });
+
+    // Burger menu
+    document.querySelector('.navbar-burger').addEventListener('click', function () {
+      this.classList.toggle('is-active');
+      document.getElementById('navbarMenu').classList.toggle('is-active');
+    });
+
+    // ----------------------------------------------------------------
+    // Server version
+    // ----------------------------------------------------------------
+    fetch('/api/alive')
+      .then(r => r.json())
+      .then(d => {
+        const el = document.getElementById('serverVersion');
+        if (el && d.version) el.textContent = 'v' + d.version;
+      })
+      .catch(() => {});
+
+    // ----------------------------------------------------------------
+    // Tabs
+    // ----------------------------------------------------------------
+    document.querySelectorAll('#deviceTypeTabs li').forEach(tab => {
+      tab.addEventListener('click', () => {
+        document.querySelectorAll('#deviceTypeTabs li').forEach(t => t.classList.remove('is-active'));
+        tab.classList.add('is-active');
+        deviceType = tab.dataset.type;
+        loadDevices();
+      });
+    });
+
+    // ----------------------------------------------------------------
+    // Range buttons
+    // ----------------------------------------------------------------
+    document.querySelectorAll('#rangeButtons button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#rangeButtons button').forEach(b => {
+          b.classList.remove('is-info');
+        });
+        btn.classList.add('is-info');
+        selectedRange = btn.dataset.range;
+        if (selectedDevice) loadChart();
+      });
+    });
+
+    // ----------------------------------------------------------------
+    // Device selector
+    // ----------------------------------------------------------------
+    document.getElementById('deviceSelect').addEventListener('change', function () {
+      selectedDevice = this.value || null;
+      if (selectedDevice) loadChart();
+    });
+
+    // ----------------------------------------------------------------
+    // Download CSV
+    // ----------------------------------------------------------------
+    document.getElementById('downloadBtn').addEventListener('click', () => {
+      if (!selectedDevice) return;
+      const url = `/api/${deviceType}s/${selectedDevice}/log/csv?range=${selectedRange}`;
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = '';
+      a.click();
+    });
+
+    // ----------------------------------------------------------------
+    // Load devices list
+    // ----------------------------------------------------------------
+    async function loadDevices() {
+      destroyChart();
+      document.getElementById('noDataMsg').style.display = 'none';
+      document.getElementById('entryCount').textContent = '';
+
+      const sel = document.getElementById('deviceSelect');
+      sel.innerHTML = '<option value="">Loading...</option>';
+      selectedDevice = null;
+
+      try {
+        const endpoint = deviceType === 'keg' ? '/api/kegs/devices' : '/api/airlocks';
+        const r = await fetch(endpoint);
+        const data = await r.json();
+
+        const devices = deviceType === 'keg'
+          ? data                           // array of id strings
+          : data.map(d => ({ id: d.id, label: d.label || d.id }));
+
+        if (!devices || devices.length === 0) {
+          sel.innerHTML = '<option value="">No devices found</option>';
+          return;
+        }
+
+        sel.innerHTML = '<option value="">Select a device</option>';
+        if (deviceType === 'keg') {
+          // Fetch full keg data to get labels
+          const kegsResp = await fetch('/api/kegs');
+          const kegsData = await kegsResp.json();
+          const labelMap = {};
+          kegsData.forEach(k => { labelMap[k.id] = k.my_label || k.id; });
+
+          devices.forEach(id => {
+            const opt = document.createElement('option');
+            opt.value = id;
+            opt.textContent = labelMap[id] || id;
+            sel.appendChild(opt);
+          });
+        } else {
+          devices.forEach(d => {
+            const opt = document.createElement('option');
+            opt.value = d.id;
+            opt.textContent = d.label || d.id;
+            sel.appendChild(opt);
+          });
+        }
+
+        // Auto-select first
+        if (sel.options.length > 1) {
+          sel.selectedIndex = 1;
+          selectedDevice = sel.value;
+          loadChart();
+        }
+      } catch (e) {
+        sel.innerHTML = '<option value="">Error loading devices</option>';
+        console.error(e);
+      }
+    }
+
+    // ----------------------------------------------------------------
+    // Load and render chart
+    // ----------------------------------------------------------------
+    async function loadChart() {
+      if (!selectedDevice) return;
+
+      document.getElementById('noDataMsg').style.display = 'none';
+      document.getElementById('entryCount').textContent = 'Loading…';
+
+      try {
+        const url = `/api/${deviceType}s/${selectedDevice}/log?range=${selectedRange}`;
+        const r = await fetch(url);
+        const entries = await r.json();
+
+        document.getElementById('entryCount').textContent =
+          entries.length === 0 ? '' : `${entries.length} data points`;
+
+        if (entries.length === 0) {
+          document.getElementById('noDataMsg').style.display = 'block';
+          destroyChart();
+          return;
+        }
+
+        renderChart(entries);
+      } catch (e) {
+        document.getElementById('entryCount').textContent = 'Error loading data';
+        console.error(e);
+      }
+    }
+
+    // ----------------------------------------------------------------
+    // Chart rendering
+    // ----------------------------------------------------------------
+    function destroyChart() {
+      if (chart) { chart.destroy(); chart = null; }
+    }
+
+    function renderChart(entries) {
+      destroyChart();
+
+      const ctx = document.getElementById('historyChart').getContext('2d');
+
+      // Timestamps are Unix seconds — convert to milliseconds for Chart.js
+      const labels = entries.map(e => e.timestamp * 1000);
+
+      let datasets, yScales;
+
+      if (deviceType === 'keg') {
+        const amountLeft    = entries.map(e => e.amount_left    != null ? parseFloat(e.amount_left)    : null);
+        const temperature   = entries.map(e => e.keg_temperature != null ? parseFloat(e.keg_temperature) : null);
+        const pctLeft       = entries.map(e => e.percent_of_beer_left != null ? parseFloat(e.percent_of_beer_left) : null);
+
+        // Determine unit label from first non-null value (best effort)
+        const unitLabel = 'Amount Left';
+
+        datasets = [
+          {
+            label: unitLabel,
+            data: amountLeft,
+            borderColor: '#3273dc',
+            backgroundColor: 'rgba(50, 115, 220, 0.08)',
+            fill: true,
+            tension: 0.2,
+            yAxisID: 'yLeft',
+            pointRadius: entries.length > 200 ? 0 : 3,
+            spanGaps: true,
+          },
+          {
+            label: 'Temperature',
+            data: temperature,
+            borderColor: '#e05d44',
+            backgroundColor: 'transparent',
+            tension: 0.2,
+            yAxisID: 'yRight',
+            pointRadius: entries.length > 200 ? 0 : 3,
+            spanGaps: true,
+          },
+          {
+            label: '% Left',
+            data: pctLeft,
+            borderColor: '#48c774',
+            backgroundColor: 'transparent',
+            tension: 0.2,
+            yAxisID: 'yLeft2',
+            pointRadius: 0,
+            spanGaps: true,
+            hidden: true,
+          },
+        ];
+
+        yScales = {
+          yLeft: {
+            type: 'linear',
+            position: 'left',
+            title: { display: true, text: 'Amount Left' },
+          },
+          yRight: {
+            type: 'linear',
+            position: 'right',
+            title: { display: true, text: 'Temperature' },
+            grid: { drawOnChartArea: false },
+          },
+          yLeft2: {
+            type: 'linear',
+            position: 'left',
+            title: { display: true, text: '% Left' },
+            display: false,
+          },
+        };
+      } else {
+        // Airlock
+        const temperature = entries.map(e => e.temperature   != null ? parseFloat(e.temperature)   : null);
+        const bpm         = entries.map(e => e.bubbles_per_min != null ? parseFloat(e.bubbles_per_min) : null);
+
+        datasets = [
+          {
+            label: 'Temperature',
+            data: temperature,
+            borderColor: '#e05d44',
+            backgroundColor: 'rgba(224, 93, 68, 0.08)',
+            fill: true,
+            tension: 0.2,
+            yAxisID: 'yLeft',
+            pointRadius: entries.length > 200 ? 0 : 3,
+            spanGaps: true,
+          },
+          {
+            label: 'Bubbles / min',
+            data: bpm,
+            borderColor: '#3273dc',
+            backgroundColor: 'transparent',
+            tension: 0.2,
+            yAxisID: 'yRight',
+            pointRadius: entries.length > 200 ? 0 : 3,
+            spanGaps: true,
+          },
+        ];
+
+        yScales = {
+          yLeft: {
+            type: 'linear',
+            position: 'left',
+            title: { display: true, text: 'Temperature' },
+          },
+          yRight: {
+            type: 'linear',
+            position: 'right',
+            title: { display: true, text: 'Bubbles / min' },
+            grid: { drawOnChartArea: false },
+          },
+        };
+      }
+
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels, datasets },
+        options: {
+          responsive: true,
+          interaction: { mode: 'index', intersect: false },
+          plugins: {
+            legend: { position: 'top' },
+            tooltip: {
+              callbacks: {
+                title: items => new Date(items[0].parsed.x).toLocaleString(),
+              },
+            },
+          },
+          scales: {
+            x: {
+              type: 'time',
+              time: { tooltipFormat: 'PPpp' },
+              title: { display: false },
+              ticks: { maxTicksLimit: 10 },
+            },
+            ...yScales,
+          },
+        },
+      });
+    }
+
+    // ----------------------------------------------------------------
+    // Init
+    // ----------------------------------------------------------------
+    loadDevices();
+  </script>
+</body>
+</html>

--- a/priv/static/index.html
+++ b/priv/static/index.html
@@ -30,6 +30,7 @@
         <div class="navbar-start">
           <a class="navbar-item" href="/index.html">Home</a>
           <a class="navbar-item" href="/taplist.html">Tap List</a>
+          <a class="navbar-item" href="/history.html">History</a>
           <div class="navbar-item has-dropdown" id="configureDropdown">
             <a class="navbar-link" onclick="toggleDropdown(event)">Configure</a>
             <div class="navbar-dropdown">

--- a/priv/static/setup.html
+++ b/priv/static/setup.html
@@ -29,6 +29,7 @@
           <div class="navbar-start">
             <a class="navbar-item" href="/index.html">Home</a>
             <a class="navbar-item" href="/taplist.html">Tap List</a>
+            <a class="navbar-item" href="/history.html">History</a>
             <div class="navbar-item has-dropdown" id="configureDropdown">
               <a class="navbar-link" onclick="toggleDropdown(event)">Configure</a>
               <div class="navbar-dropdown">

--- a/priv/static/tap-handles.html
+++ b/priv/static/tap-handles.html
@@ -69,6 +69,7 @@
         <div class="navbar-start">
           <a class="navbar-item" href="/index.html">Home</a>
           <a class="navbar-item" href="/taplist.html">Tap List</a>
+          <a class="navbar-item" href="/history.html">History</a>
           <div class="navbar-item has-dropdown" id="configureDropdown">
             <a class="navbar-link" onclick="toggleDropdown(event)">Configure</a>
             <div class="navbar-dropdown">

--- a/priv/static/taplist-setup.html
+++ b/priv/static/taplist-setup.html
@@ -38,6 +38,7 @@
         <div class="navbar-start">
           <a class="navbar-item" href="/index.html">Home</a>
           <a class="navbar-item" href="/taplist.html">Tap List</a>
+          <a class="navbar-item" href="/history.html">History</a>
           <div class="navbar-item has-dropdown" id="configureDropdown">
             <a class="navbar-link" onclick="toggleDropdown(event)">Configure</a>
             <div class="navbar-dropdown">

--- a/priv/static/transfer-scales.html
+++ b/priv/static/transfer-scales.html
@@ -18,6 +18,7 @@
         <div class="navbar-start">
           <a class="navbar-item" href="/index.html">Home</a>
           <a class="navbar-item" href="/taplist.html">Tap List</a>
+          <a class="navbar-item" href="/history.html">History</a>
           <div class="navbar-item has-dropdown" id="configureDropdown">
             <a class="navbar-link" onclick="toggleDropdown(event)">Configure</a>
             <div class="navbar-dropdown">


### PR DESCRIPTION
## Summary

- New `DataLog` model (`lib/open_plaato_keg/models/data_log.ex`) — DETS-backed time-series store keyed by `{device_type, device_id, unix_timestamp}`. Includes an ETS throttle (60s minimum interval for kegs; airlocks unthrottled) and a `prune/1` function for retention management.
- Keg readings (`amount_left`, `keg_temperature`, `percent_of_beer_left`, `is_pouring`) are logged on every hardware TCP packet (respecting throttle).
- Airlock readings (`temperature`, `bubbles_per_min`) are logged from both TCP hardware connections and HTTP POST submissions.
- Four new API endpoints for querying log data as JSON or downloading as CSV, with range query parameter (`1h`, `6h`, `24h`, `7d`, `30d`).
- New `history.html` page with Chart.js dual-axis line graphs and a one-click CSV download button.
- **History** link added to the navbar on all pages.

## New API endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/kegs/:id/log?range=24h` | JSON log entries |
| GET | `/api/kegs/:id/log/csv?range=30d` | CSV download |
| GET | `/api/airlocks/:id/log?range=24h` | JSON log entries |
| GET | `/api/airlocks/:id/log/csv?range=30d` | CSV download |

## Test plan

- [ ] Start the app fresh — confirm `data_log.bin` is created alongside other DETS files
- [ ] Connect a keg; wait 2+ minutes — confirm `/api/kegs/:id/log` returns entries
- [ ] POST to `/api/airlocks/test/data` with temperature/bubbles_per_min — confirm `/api/airlocks/test/log` returns entries
- [ ] Open `/history.html`, select a keg device and a time range — confirm graph renders
- [ ] Switch to Airlocks tab — confirm graph switches to temperature/BPM axes
- [ ] Click **Download CSV** — confirm file downloads with correct columns
- [ ] Verify `History` link appears in navbar on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)