### PR TITLE
fix: use Enum.map_join to satisfy Credo linter

### DIFF
--- a/lib/open_plaato_keg/models/data_log.ex
+++ b/lib/open_plaato_keg/models/data_log.ex
@@ -117,7 +117,6 @@ defmodule OpenPlaatoKeg.Models.DataLog do
       end)
 
     [headers | rows]
-    |> Enum.map(&Enum.join(&1, ","))
-    |> Enum.join("\n")
+    |> Enum.map_join("\n", &Enum.join(&1, ","))
   end
 end


### PR DESCRIPTION
Credo flagged `Enum.map/2 |> Enum.join/2` in `DataLog.rows_to_csv/2` as a refactoring opportunity — `Enum.map_join/3` is more efficient. This was missed before PR #2 was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)