### PR TITLE
feat: Watchtower update trigger + CO2 bottle SVG on homepage

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,21 @@
 version: "3.6"
 services:
+  watchtower:
+    image: containrrr/watchtower
+    container_name: watchtower
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Mount host Docker credentials for private registries (e.g. GHCR):
+      # - /root/.docker/config.json:/config.json
+    environment:
+      - WATCHTOWER_HTTP_API_UPDATE=true
+      # Optional: set a token and enter it in the Keg Setup UI
+      # - WATCHTOWER_HTTP_API_TOKEN=changeme
+      - WATCHTOWER_POLL_INTERVAL=3600
+    ports:
+      - 8080:8080
+
   vernemq:
     image: erlio/docker-vernemq:latest
     container_name: vernemq

--- a/lib/open_plaato_keg/app_config.ex
+++ b/lib/open_plaato_keg/app_config.ex
@@ -1,7 +1,13 @@
 defmodule OpenPlaatoKeg.AppConfig do
   require Logger
 
-  @defaults %{airlock_enabled: true, brewfather_user_id: "", brewfather_api_key: ""}
+  @defaults %{
+    airlock_enabled: true,
+    brewfather_user_id: "",
+    brewfather_api_key: "",
+    watchtower_url: "",
+    watchtower_token: ""
+  }
 
   @doc "Load persisted config from disk into Application env. Call once at startup."
   def load do
@@ -13,7 +19,9 @@ defmodule OpenPlaatoKeg.AppConfig do
             loaded = %{
               airlock_enabled: Map.get(map, "airlock_enabled", @defaults.airlock_enabled),
               brewfather_user_id: Map.get(map, "brewfather_user_id", @defaults.brewfather_user_id),
-              brewfather_api_key: Map.get(map, "brewfather_api_key", @defaults.brewfather_api_key)
+              brewfather_api_key: Map.get(map, "brewfather_api_key", @defaults.brewfather_api_key),
+              watchtower_url: Map.get(map, "watchtower_url", @defaults.watchtower_url),
+              watchtower_token: Map.get(map, "watchtower_token", @defaults.watchtower_token)
             }
             Application.put_env(:open_plaato_keg, :app_config, Map.merge(@defaults, loaded))
 

--- a/lib/open_plaato_keg/http_router.ex
+++ b/lib/open_plaato_keg/http_router.ex
@@ -1000,6 +1000,55 @@ defmodule OpenPlaatoKeg.HttpRouter do
   end
 
   # ============================================
+  # Watchtower / Software Update
+  # ============================================
+
+  get "api/config/watchtower" do
+    url = OpenPlaatoKeg.AppConfig.get(:watchtower_url, "")
+    token = OpenPlaatoKeg.AppConfig.get(:watchtower_token, "")
+    json_response(conn, 200, %{url: url, has_token: token != ""})
+  end
+
+  post "api/config/watchtower" do
+    p = conn.body_params || %{}
+    url = to_string(p["url"] || "") |> String.trim()
+    token = to_string(p["token"] || "") |> String.trim()
+
+    OpenPlaatoKeg.AppConfig.put(:watchtower_url, url)
+    OpenPlaatoKeg.AppConfig.put(:watchtower_token, token)
+
+    json_response(conn, 200, %{status: "ok", url: url, has_token: token != ""})
+  end
+
+  post "api/system/update" do
+    url = OpenPlaatoKeg.AppConfig.get(:watchtower_url, "")
+    token = OpenPlaatoKeg.AppConfig.get(:watchtower_token, "")
+
+    if url == "" do
+      json_response(conn, 400, %{error: "watchtower_url not configured"})
+    else
+      headers =
+        if token != "",
+          do: [{"Authorization", "Bearer #{token}"}],
+          else: []
+
+      case Req.post("#{url}/v1/update", headers: headers) do
+        {:ok, %{status: status}} when status in 200..299 ->
+          Logger.info("Watchtower update triggered successfully", [])
+          json_response(conn, 200, %{status: "ok"})
+
+        {:ok, %{status: status, body: body}} ->
+          Logger.warning("Watchtower returned #{status}: #{inspect(body)}", [])
+          json_response(conn, 502, %{error: "watchtower_error", status: status})
+
+        {:error, reason} ->
+          Logger.error("Watchtower request failed: #{inspect(reason)}", [])
+          json_response(conn, 502, %{error: "request_failed"})
+      end
+    end
+  end
+
+  # ============================================
   # Other Endpoints
   # ============================================
 

--- a/priv/static/index.html
+++ b/priv/static/index.html
@@ -142,6 +142,59 @@
             const isLow = percentLeft < 20;
             const fillPct = Math.min(100, Math.max(0, percentLeft)).toFixed(1);
 
+            // CO2 bottle SVG — replaces the flat volume + progress bar for CO2 mode
+            let volumeSection;
+            if (isCO2) {
+                // Bottle path: neck (x=40–60) narrows into body (x=18–82), rounded bottom
+                const bottlePath = "M40,15 L60,15 L60,37 Q80,47 82,58 L82,152 Q82,162 70,162 L30,162 Q18,162 18,152 L18,58 Q20,47 40,37 Z";
+                // Fill from bottom up; entire path height = y15 to y162 = 147 units
+                const fillH = Math.max(0, (Math.min(100, percentLeft) / 100) * 147).toFixed(1);
+                const fillY = (162 - parseFloat(fillH)).toFixed(1);
+                // Unique clip-path ID per keg
+                const cid = 'bcl' + kegData.id;
+                volumeSection = `
+                    <div class="keg-bottle-section">
+                        <svg class="co2-bottle-svg" viewBox="0 0 100 172" xmlns="http://www.w3.org/2000/svg" aria-label="CO2 level: ${percentLeft.toFixed(0)}%">
+                            <defs>
+                                <clipPath id="${cid}">
+                                    <path d="${bottlePath}"/>
+                                </clipPath>
+                            </defs>
+                            <!-- Dark bottle interior -->
+                            <path d="${bottlePath}" class="co2-bottle-bg"/>
+                            <!-- Gas fill level -->
+                            <rect x="14" y="${fillY}" width="74" height="${fillH}" clip-path="url(#${cid})" class="co2-bottle-fill${isLow ? ' is-low' : ''}"/>
+                            <!-- Subtle left-edge gloss -->
+                            <rect x="18" y="62" width="10" height="70" rx="5" clip-path="url(#${cid})" class="co2-bottle-gloss"/>
+                            <!-- Bottle outline -->
+                            <path d="${bottlePath}" class="co2-bottle-stroke"/>
+                            <!-- Neck side lines -->
+                            <line x1="40" y1="15" x2="40" y2="37" class="co2-neck-line"/>
+                            <line x1="60" y1="15" x2="60" y2="37" class="co2-neck-line"/>
+                            <!-- Valve cap -->
+                            <rect x="36" y="3" width="28" height="14" rx="5" class="co2-valve"/>
+                            <line x1="50" y1="3" x2="50" y2="17" class="co2-valve-divider"/>
+                            <!-- Amount + unit + percent, centered in bottle body -->
+                            <text x="50" y="100" text-anchor="middle" dominant-baseline="central" class="co2-amount">${amountLeft.toFixed(1)}</text>
+                            <text x="50" y="118" text-anchor="middle" dominant-baseline="central" class="co2-unit">${volumeUnit}</text>
+                            <text x="50" y="136" text-anchor="middle" dominant-baseline="central" class="co2-pct${isLow ? ' is-low' : ''}">${percentLeft.toFixed(0)}%</text>
+                        </svg>
+                    </div>
+                `;
+            } else {
+                volumeSection = `
+                    <div class="keg-volume">
+                        <span class="keg-volume-number">${amountLeft.toFixed(2)}</span><span class="keg-volume-unit">${volumeUnit}</span>
+                    </div>
+                    <div class="keg-remaining">
+                        <div class="keg-progress-track">
+                            <div class="keg-progress-fill${isLow ? ' is-low' : ''}" style="width:${fillPct}%"></div>
+                        </div>
+                        <div class="keg-remaining-text">${percentLeft.toFixed(1)}% remaining</div>
+                    </div>
+                `;
+            }
+
             const card = `
                 <div class="card keg-card${isCO2 ? ' is-co2' : ''}" data-keg-id="${kegData.id}">
                     <div class="keg-header">
@@ -154,15 +207,7 @@
                             <span class="keg-temp-badge">${!isNaN(temperature) ? temperature.toFixed(1) + tempUnit : '--'}</span>
                         </div>
                     </div>
-                    <div class="keg-volume">
-                        <span class="keg-volume-number">${amountLeft.toFixed(2)}</span><span class="keg-volume-unit">${volumeUnit}</span>
-                    </div>
-                    <div class="keg-remaining">
-                        <div class="keg-progress-track">
-                            <div class="keg-progress-fill${isLow ? ' is-low' : ''}" style="width:${fillPct}%"></div>
-                        </div>
-                        <div class="keg-remaining-text">${percentLeft.toFixed(1)}% ${isCO2 ? 'CO\u2082 remaining' : 'remaining'}</div>
-                    </div>
+                    ${volumeSection}
                     ${!isCO2 && lastPour > 0 ? `<div class="keg-footer"><span class="keg-last-pour">Last pour · ${Math.round(pourValue)} ${pourUnit}</span></div>` : ''}
                 </div>
             `;

--- a/priv/static/setup.html
+++ b/priv/static/setup.html
@@ -414,6 +414,42 @@
             </div>
           </div>
 
+          <!-- Software Update -->
+          <div class="box section-box">
+            <h2 class="title is-4">Software Update</h2>
+            <p class="subtitle is-6">Trigger a Watchtower container update. Requires Watchtower running with HTTP API enabled.</p>
+
+            <div class="field">
+              <label class="label">Watchtower URL</label>
+              <div class="control">
+                <input class="input" type="text" id="watchtowerUrl"
+                       placeholder="http://watchtower:8080" />
+              </div>
+              <p class="help">The base URL of your Watchtower instance (e.g. <code>http://watchtower:8080</code>)</p>
+            </div>
+
+            <div class="field">
+              <label class="label">API Token (optional)</label>
+              <div class="control">
+                <input class="input" type="password" id="watchtowerToken"
+                       placeholder="Leave blank if not set" />
+              </div>
+              <p class="help">Set this if Watchtower is configured with <code>WATCHTOWER_HTTP_API_TOKEN</code></p>
+            </div>
+
+            <div class="field is-grouped">
+              <div class="control">
+                <button class="button is-info" onclick="saveWatchtowerConfig()">Save</button>
+              </div>
+              <div class="control">
+                <button class="button is-warning" id="triggerUpdateBtn" onclick="triggerUpdate()">
+                  Trigger Update
+                </button>
+              </div>
+            </div>
+            <p class="help" id="updateStatus"></p>
+          </div>
+
         </div>
       </section>
     </div>
@@ -859,6 +895,7 @@
       loadConnectedKegs();
       setInterval(loadConnectedKegs, 10000);
       loadBeverages();
+      loadWatchtowerConfig();
 
       function getSelectedKeg() {
         const kegId = kegIdSelect.value;
@@ -1119,6 +1156,66 @@
 
       function setSensitivity(level) {
         sendCommand("sensitivity", { value: level.toString() });
+      }
+
+      async function loadWatchtowerConfig() {
+        try {
+          const res = await fetch('/api/config/watchtower');
+          const data = await res.json();
+          document.getElementById('watchtowerUrl').value = data.url || '';
+          if (data.has_token) {
+            document.getElementById('watchtowerToken').placeholder = '(token saved — leave blank to keep)';
+          }
+        } catch (_) {}
+      }
+
+      async function saveWatchtowerConfig() {
+        const url = document.getElementById('watchtowerUrl').value.trim();
+        const token = document.getElementById('watchtowerToken').value.trim();
+        try {
+          const res = await fetch('/api/config/watchtower', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ url, token }),
+          });
+          const data = await res.json();
+          if (data.status === 'ok') {
+            showToast('Watchtower config saved', 'success');
+            document.getElementById('watchtowerToken').value = '';
+            if (data.has_token) {
+              document.getElementById('watchtowerToken').placeholder = '(token saved — leave blank to keep)';
+            }
+          } else {
+            showToast('Failed to save config', 'danger');
+          }
+        } catch (err) {
+          showToast(`Error: ${err.message}`, 'danger');
+        }
+      }
+
+      async function triggerUpdate() {
+        const btn = document.getElementById('triggerUpdateBtn');
+        const status = document.getElementById('updateStatus');
+        btn.classList.add('is-loading');
+        btn.disabled = true;
+        status.textContent = '';
+        try {
+          const res = await fetch('/api/system/update', { method: 'POST' });
+          const data = await res.json();
+          if (res.ok) {
+            status.textContent = 'Update triggered. Watchtower will pull and restart the container shortly.';
+            status.className = 'help has-text-success';
+          } else {
+            status.textContent = data.error || 'Update failed';
+            status.className = 'help has-text-danger';
+          }
+        } catch (err) {
+          status.textContent = `Error: ${err.message}`;
+          status.className = 'help has-text-danger';
+        } finally {
+          btn.classList.remove('is-loading');
+          btn.disabled = false;
+        }
       }
 
       async function triggerOtaUpdate() {

--- a/priv/static/style.css
+++ b/priv/static/style.css
@@ -923,6 +923,84 @@ body {
   background: linear-gradient(90deg, #22c55e, #16a34a);
 }
 
+/* CO2 bottle SVG */
+.keg-bottle-section {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid rgba(34, 197, 94, 0.1);
+  border-bottom: 1px solid rgba(34, 197, 94, 0.1);
+}
+
+.co2-bottle-svg {
+  width: 90px;
+  height: auto;
+}
+
+.co2-bottle-bg {
+  fill: rgba(0, 0, 0, 0.45);
+}
+
+.co2-bottle-fill {
+  fill: rgba(34, 197, 94, 0.65);
+}
+
+.co2-bottle-fill.is-low {
+  fill: rgba(239, 68, 68, 0.65);
+}
+
+.co2-bottle-gloss {
+  fill: rgba(255, 255, 255, 0.055);
+}
+
+.co2-bottle-stroke {
+  fill: none;
+  stroke: rgba(34, 197, 94, 0.55);
+  stroke-width: 1.5;
+}
+
+.co2-neck-line {
+  stroke: rgba(255, 255, 255, 0.1);
+  stroke-width: 0.8;
+}
+
+.co2-valve {
+  fill: rgba(148, 163, 184, 0.45);
+  stroke: rgba(148, 163, 184, 0.75);
+  stroke-width: 1;
+}
+
+.co2-valve-divider {
+  stroke: rgba(148, 163, 184, 0.35);
+  stroke-width: 0.8;
+}
+
+.co2-amount {
+  font-family: var(--font-mono);
+  font-size: 19px;
+  font-weight: 700;
+  fill: rgba(254, 252, 232, 0.95);
+}
+
+.co2-unit {
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 500;
+  fill: rgba(254, 252, 232, 0.45);
+}
+
+.co2-pct {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  fill: rgba(34, 197, 94, 0.65);
+  letter-spacing: 0.05em;
+}
+
+.co2-pct.is-low {
+  fill: rgba(239, 68, 68, 0.75);
+}
+
 .co2-badge {
   font-size: 0.7rem;
   font-weight: 700;


### PR DESCRIPTION
## Summary

- **Software Update button**: adds a "Software Update" section to Keg Setup where you can configure a Watchtower URL + optional API token. Clicking "Trigger Update" calls `POST /api/system/update` which hits Watchtower's HTTP API to pull and restart the container. Config is persisted to `app_config.json`. Docker Compose example Watchtower service included.
- **CO2 bottle icon**: when a keg is in CO2 mode, the homepage card replaces the flat volume number + progress bar with an inline SVG gas cylinder. The fill level rises from the bottom based on the current CO2 percentage, turns red below 20%, and displays the amount, unit, and percentage as text inside the bottle.

## Test plan

- [ ] Enable CO2 mode on a keg in Keg Setup — homepage card should show the bottle SVG with correct fill level
- [ ] Verify fill turns red when CO2 % drops below 20
- [ ] Verify beer-mode kegs are unaffected (still show big number + progress bar)
- [ ] Multiple CO2 kegs on the same page each render their own bottle correctly
- [ ] In Keg Setup → Software Update: enter Watchtower URL + optional token, save, reload page — values persist
- [ ] With Watchtower running (`WATCHTOWER_HTTP_API_UPDATE=true`), click Trigger Update — container pulls and restarts
- [ ] `POST /api/system/update` with no URL configured returns 400
- [ ] `GET /api/config/watchtower` and `POST /api/config/watchtower` work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)