### PR TITLE
fix: expose Watchtower error detail in API + UI

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,9 @@ services:
     image: containrrr/watchtower
     container_name: watchtower
     restart: always
+    # Restrict Watchtower to only monitor the open-plaato-keg container.
+    # Change this if your container has a different name.
+    command: open-plaato-keg
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # Mount host Docker credentials for private registries (e.g. GHCR):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,6 @@ services:
     image: containrrr/watchtower
     container_name: watchtower
     restart: always
-    # Restrict Watchtower to only monitor the open-plaato-keg container.
-    # Change this if your container has a different name.
-    command: open-plaato-keg
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # Mount host Docker credentials for private registries (e.g. GHCR):

--- a/lib/open_plaato_keg/http_router.ex
+++ b/lib/open_plaato_keg/http_router.ex
@@ -1041,9 +1041,15 @@ defmodule OpenPlaatoKeg.HttpRouter do
           Logger.warning("Watchtower returned #{status}: #{inspect(body)}", [])
           json_response(conn, 502, %{error: "watchtower_error", status: status})
 
+        {:error, %{reason: reason}} ->
+          msg = Exception.message(reason)
+          Logger.error("Watchtower request failed: #{msg}", [])
+          json_response(conn, 502, %{error: "request_failed", detail: msg})
+
         {:error, reason} ->
-          Logger.error("Watchtower request failed: #{inspect(reason)}", [])
-          json_response(conn, 502, %{error: "request_failed"})
+          msg = inspect(reason)
+          Logger.error("Watchtower request failed: #{msg}", [])
+          json_response(conn, 502, %{error: "request_failed", detail: msg})
       end
     end
   end

--- a/priv/static/setup.html
+++ b/priv/static/setup.html
@@ -1206,7 +1206,8 @@
             status.textContent = 'Update triggered. Watchtower will pull and restart the container shortly.';
             status.className = 'help has-text-success';
           } else {
-            status.textContent = data.error || 'Update failed';
+            const detail = data.detail ? ` (${data.detail})` : '';
+            status.textContent = (data.error || 'Update failed') + detail;
             status.className = 'help has-text-danger';
           }
         } catch (err) {


### PR DESCRIPTION
## Summary

- **Error detail**: `POST /api/system/update` now returns the actual connection error reason (e.g. "connection refused", "nxdomain") in the response body instead of just `"request_failed"`. The UI displays it inline so the root cause is immediately visible without needing to check server logs.

## Test plan

- [ ] With an incorrect Watchtower URL, click Trigger Update — error message should show the specific reason (e.g. connection refused)
- [ ] With a correct Watchtower URL, update still triggers successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)