### PR TITLE
fix: persistent DB volume mount + Watchtower empty response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ services:
       - 1234:1234
       - 8085:8085
     restart: always
+    volumes:
+      # Persist the database across container updates — without this your
+      # keg data will be lost every time the container is recreated.
+      # Unraid users: change the host path to your appdata share, e.g.
+      #   /mnt/user/appdata/open-plaato-keg:/db
+      - ./data:/db
     environment:
       - DATABASE_FILE_PATH=/db/keg_data.bin
       - KEG_LISTENER_PORT=1234

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,22 @@ services:
     ports:
       - 8080:8080
 
+  open_plaato_keg:
+    image: ghcr.io/darkjaeger/open-plaato-keg:latest
+    container_name: open_plaato_keg
+    ports:
+      - 1234:1234
+      - 8085:8085
+    restart: always
+    volumes:
+      # Persist keg data across container updates.
+      # Unraid: change host path to /mnt/user/appdata/open-plaato-keg:/db
+      - ./data:/db
+    environment:
+      - DATABASE_FILE_PATH=/db/keg_data.bin
+      - KEG_LISTENER_PORT=1234
+      - HTTP_LISTENER_PORT=8085
+
   vernemq:
     image: erlio/docker-vernemq:latest
     container_name: vernemq

--- a/priv/static/setup.html
+++ b/priv/static/setup.html
@@ -1201,11 +1201,11 @@
         status.textContent = '';
         try {
           const res = await fetch('/api/system/update', { method: 'POST' });
-          const data = await res.json();
           if (res.ok) {
             status.textContent = 'Update triggered. Watchtower will pull and restart the container shortly.';
             status.className = 'help has-text-success';
           } else {
+            const data = await res.json().catch(() => ({}));
             const detail = data.detail ? ` (${data.detail})` : '';
             status.textContent = (data.error || 'Update failed') + detail;
             status.className = 'help has-text-danger';


### PR DESCRIPTION
## Summary

- **Persistent database volume**: the sample docker-compose and README were setting `DATABASE_FILE_PATH=/db/keg_data.bin` but never mounting a volume for `/db`, causing all keg data to be lost on every container update. Adds `./data:/db` volume with a note for Unraid users to use `/mnt/user/appdata/open-plaato-keg:/db`.
- **Watchtower empty response body**: Watchtower returns `200` with no body on success, causing `res.json()` to throw "Unexpected end of JSON input" in the UI. JSON is now only parsed on error responses.

## Test plan

- [ ] Click Trigger Update with Watchtower running — success message shown, no JSON error
- [ ] Container data persists after `docker compose pull && docker compose up -d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)