### PR TITLE
[codex] Fix persisting keg internal metadata on connect

### DIFF
--- a/lib/open_plaato_keg/keg_data_processor.ex
+++ b/lib/open_plaato_keg/keg_data_processor.ex
@@ -43,6 +43,7 @@ defmodule OpenPlaatoKeg.KegDataProcessor do
       cond do
         state[:device_type] != nil -> state
         airlock_data?(data) -> Map.put(state, :device_type, :airlock)
+        internal_keg_data?(data) -> Map.put(state, :device_type, :keg)
         keg_data?(data) -> Map.put(state, :device_type, :keg)
         true -> state
       end
@@ -89,6 +90,16 @@ defmodule OpenPlaatoKeg.KegDataProcessor do
       Keyword.has_key?(data, :percent_of_beer_left) or
       Keyword.has_key?(data, :is_pouring) or
       Keyword.has_key?(data, :firmware_version)
+  end
+
+  defp internal_keg_data?(data) do
+    case Keyword.get(data, :internal) do
+      %{} = internal ->
+        Enum.any?(["dev", "fw", "tmpl", "build", "ver"], &Map.has_key?(internal, &1))
+
+      _ ->
+        false
+    end
   end
 
   # Valid pour range per unit. Lower bound catches near-zero scale noise;


### PR DESCRIPTION
## What changed
Treat a Plaato-style internal metadata packet as enough to classify a connection as a keg.

## Why
Some scales send the boot-time internal packet before any of the normal keg status pins. We were decoding that packet correctly, but because the connection had not been classified as a keg yet, the metadata was cached/ignored instead of being persisted to DETS.

## Impact
This restores the setup-page system fields like Device, Version, Firmware, Build, Template, Heartbeat, and Buffer for scales that send internal metadata early in the connection.

## Root cause
The processor only treated normal keg status pins as proof that a connection was a keg. An internal-only boot packet was not enough to classify the connection, so the metadata never made it into KegData.

## Validation
- Reproduced with debug logging on affected scales
- Confirmed raw internal packets were present but missing from persisted snapshots before the fix
- Confirmed the metadata persisted correctly after the fix
- Ran mix compile