### PR TITLE
fix: detect Airlock v3 before sticky device_type check

### DIFF
--- a/lib/open_plaato_keg/keg_data_processor.ex
+++ b/lib/open_plaato_keg/keg_data_processor.ex
@@ -39,10 +39,17 @@ defmodule OpenPlaatoKeg.KegDataProcessor do
       end
 
     # Detect device type from pin keys once and cache it in state.
+    # `airlock_data?` is checked BEFORE the sticky `state[:device_type] != nil`
+    # clause because the Plaato Airlock v3 (NodeMCU, fw 0.5.1) sends an
+    # `internal` metadata packet (containing dev/build/ver) before its first
+    # V99/V100/V101 hardware pin write. That metadata matches
+    # `internal_keg_data?/1` and would otherwise lock the device as `:keg`
+    # before the actual airlock pins arrive (issue #10). The airlock virtual
+    # pins are device-specific and should always override.
     state =
       cond do
-        state[:device_type] != nil -> state
         airlock_data?(data) -> Map.put(state, :device_type, :airlock)
+        state[:device_type] != nil -> state
         internal_keg_data?(data) -> Map.put(state, :device_type, :keg)
         keg_data?(data) -> Map.put(state, :device_type, :keg)
         true -> state


### PR DESCRIPTION
## Summary

Fixes #10 — Plaato Airlock v3 (NodeMCU firmware `0.5.1`, `dev=NodeMCU`) is misclassified as a Keg because its `internal` metadata packet arrives before the first V99/V100/V101 hardware pin write.

### Root cause

In `KegDataProcessor.process/2`, the device-type classification cond is:

```elixir
cond do
  state[:device_type] != nil -> state              # sticky once set
  airlock_data?(data) -> Map.put(state, :device_type, :airlock)
  internal_keg_data?(data) -> Map.put(state, :device_type, :keg)
  keg_data?(data) -> Map.put(state, :device_type, :keg)
  true -> state
end
```

`internal_keg_data?/1` matches when the `internal` map has any of `["dev", "fw", "tmpl", "build", "ver"]`. The v3 Airlock's internal looks like:

```elixir
%{"buff-in" => "1024", "build" => "Mar 22 2018 17:31:06", "dev" => "NodeMCU",
  "h-beat" => "10", "ver" => "0.5.1"}
```

It has `build`, `dev`, `ver` — so it matches `internal_keg_data?` and `device_type` gets locked to `:keg`. When V100 (`airlock_bubble_count`) and V101 (`airlock_temperature`) arrive next, the sticky `state[:device_type] != nil` clause short-circuits, and all subsequent airlock telemetry is routed through `process_keg/2` (which also emits spurious `Ignoring out-of-range last_pour=0.0 kg` warnings).

The Keg v2.0.10a (ESP32) doesn't hit this because:
- Its first non-internal packets carry keg-specific pins (`amount_left`, `keg_temperature`, etc.), confirming the `:keg` classification correctly
- Airlock pins V99/V100/V101 never appear in keg traffic

## Fix

Reorder the cond so `airlock_data?` is checked **before** the sticky check. V99/V100/V101 are airlock-specific virtual pins and should always override a tentative keg classification from generic `internal` metadata. One-line move, kept the existing `internal_keg_data?` heuristic intact for kegs.

## Test plan

- [x] Verified end-to-end on two independent v3 Airlock units. Both now classify correctly as `:airlock`, appear in `/airlock-setup.html`, and show live temperature + bubble count via WebSocket.
- [x] Keg (firmware 2.0.10a, `dev=ESP32`) regression-tested — still classifies correctly. (The airlock pins V99/V100/V101 don't appear in keg traffic, so `airlock_data?` evaluates false on the first packets containing only the keg's internal metadata, leaving the existing classification path intact.)
- [x] Spurious `Ignoring out-of-range last_pour=0.0 kg` warnings from misclassified airlock packets no longer appear in logs.

### Reproduction (before)

```
[info] Registering socket for keg a17a1100000000001111000022220000
[info] decoded=[id: "a17a1100..."]
[info] decoded=[internal: %{"dev" => "NodeMCU", "build" => "Mar 22 2018 17:31:06", "ver" => "0.5.1", ...}]
[info] decoded=[airlock_bubble_count: "1"]     # ← routed through process_keg
[info] decoded=[airlock_temperature: "30.375"] # ← routed through process_keg
[warning] Ignoring out-of-range last_pour=0.0 kg for keg a17a1100...
```

### After patch

Same input bytes — `airlock_bubble_count` packet now matches `airlock_data?`, `device_type` is set to `:airlock`, all subsequent packets route through `process_airlock/2`. Device appears in `/airlock-setup.html` with live values.